### PR TITLE
Fix hash calculation for descriptor set layouts caching.

### DIFF
--- a/Source/Core/DescriptorSetLayoutCache.cpp
+++ b/Source/Core/DescriptorSetLayoutCache.cpp
@@ -48,6 +48,8 @@ namespace vez
             bitfield->descriptorType = setResources[i].resourceType;
             bitfield->descriptorCount = setResources[i].arraySize;
             bitfield->stageFlags = setResources[i].stages;
+            
+            ++bitfield;
         }
 
         return hash;


### PR DESCRIPTION
The hash calculated for caching descriptor set layouts only considers the last resource of the selected set.

On an unrelated note, I don't like the usage of bitfields here; `DescriptorSetLayoutBindingBitField` without being packed already fits in a 64-bit register anyways.